### PR TITLE
Fix device type label in queries

### DIFF
--- a/GoogleSEO/google_brand_click_impression.ipynb
+++ b/GoogleSEO/google_brand_click_impression.ipynb
@@ -36,7 +36,7 @@
     "        AVG(CAST(REPLACE(ctr, '%', '') AS DOUBLE) / 100.0) AS avg_ctr,\n",
     "        AVG(rank) AS avg_rank\n",
     "    FROM (\n",
-    "        SELECT *, 'desktop' AS type\n",
+    "        SELECT *, 'mobile' AS type\n",
     "        FROM read_csv_auto('{CSV_PATH}')\n",
     "    )\n",
     "    GROUP BY DATE_TRUNC('week', date), type\n",

--- a/GoogleSEO/google_click_impression.ipynb
+++ b/GoogleSEO/google_click_impression.ipynb
@@ -36,7 +36,7 @@
     "        AVG(CAST(REPLACE(ctr, '%', '') AS DOUBLE) / 100.0) AS avg_ctr,\n",
     "        AVG(rank) AS avg_rank\n",
     "    FROM (\n",
-    "        SELECT *, 'desktop' AS type\n",
+    "        SELECT *, 'mobile' AS type\n",
     "        FROM read_csv_auto('{CSV_PATH}')\n",
     "    )\n",
     "    GROUP BY DATE_TRUNC('week', date), type\n",


### PR DESCRIPTION
## Summary
- fix query label for device type in Google Click and Brand notebooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842997941908328ad18ab523718d0a6